### PR TITLE
Use `browser-sync` to improve development experience

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var browserify  = require('browserify');
 var babelify    = require('babelify');
 var source      = require('vinyl-source-stream');
 var clean       = require('gulp-clean');
+var browserSync = require('browser-sync').create();
 
 gulp.task('clean', function(){
   return gulp.src(['dist/*'], {read:false})
@@ -15,21 +16,43 @@ gulp.task('copy', ['clean'], function() {
     .pipe(gulp.dest('dist'));
 });
 
+var scriptsEntries = [
+  'app/scripts/build.js',
+  'app/scripts/buildbot_client.js',
+  'app/scripts/config.js',
+  'app/scripts/main.js',
+  'app/scripts/ui.js'
+];
+
+var htmlEntries = ['app/index.html'];
+
+var stylesEntries = [
+  'app/styles/main.css'
+];
+
 gulp.task('build', ['copy'], function () {
-  var entries = [
-    'app/scripts/build.js',
-    'app/scripts/buildbot_client.js',
-    'app/scripts/config.js',
-    'app/scripts/main.js',
-    'app/scripts/ui.js'
-  ];
-  return browserify({entries: entries, debug: true})
-      .transform("babelify", { presets: ["es2015"] })
-      .bundle()
-      .pipe(source('app.js'))
-      .pipe(gulp.dest('./dist/'));
+  return browserify({
+    entries: scriptsEntries,
+    debug: true
+  }).transform("babelify", { presets: ["es2015"] })
+    .bundle()
+    .pipe(source('app.js'))
+    .pipe(gulp.dest('./dist/'));
 });
 
-gulp.task('serve', ['build'], serve('dist'));
+gulp.task('watch', ['build'], function (done) {
+  browserSync.reload();
+  done();
+})
 
-gulp.task('default', ['clean', 'copy', 'build', 'serve']);
+gulp.task('default', ['clean', 'copy', 'build'], function () {
+  browserSync.init({
+    server: {
+      baseDir: './dist'
+    }
+  });
+
+  const entries = scriptsEntries.concat(htmlEntries).concat(stylesEntries);
+
+  gulp.watch(entries, ['watch']);
+});

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
     "gulp-clean": "^0.4.0",
     "gulp-serve": "^1.4.0",
     "vinyl-source-stream": "^2.0.0"
+  },
+  "devDependencies": {
+    "browser-sync": "^2.23.6"
   }
 }


### PR DESCRIPTION
r? @ferjm 

Without `watchify`, we'll need to relaunch `gulp` after file changes so I'd like to use `watchify` to help us keep files up-to-date when we have any file changes from the `entries`.