### PR TITLE
Locally cache server-side cached builds

### DIFF
--- a/app/scripts/buildbot_client.js
+++ b/app/scripts/buildbot_client.js
@@ -44,10 +44,16 @@ export class BuildbotClient {
     return this._fetchBuilders()
     .then(builders => {
       // FIXME (ferjm): check that we really want to fetch from all the builders.
+      if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage('current');
+      }
       this._pool.run(this._fetchBuildRunnable);
       return this._fetchBuilds(builders, CURRENT);
     })
     .then(({builders}) => {
+      if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage('cached');
+      }
       // For each builder we get the list of current and cached builds.
       // We start with the current builds, so we can display their progress
       // as soon as possible.
@@ -134,7 +140,7 @@ export class BuildbotClient {
   }
 
   _fetchBuildRunnable(data, done, progress) {
-    return fetch(data.path)
+    return fetch(data.path, { mode: 'cors' })
     .then(res => {
       return res.json();
     }).then(json => {

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,5 +1,13 @@
 importScripts('vendor/sw-toolbox/sw-toolbox.js');
 
+self.addEventListener('install', function(event) {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function(event) {
+  self.clients.claim();
+});
+
 self.toolbox.precache([
   'index.html',
   './img/less.png',
@@ -8,6 +16,24 @@ self.toolbox.precache([
   './app.js',
   './vendor/threads.browser.js'
 ]);
+
+toolbox.options.debug = false;
+
+var fetchingCachedBuilds = false;
+
+self.addEventListener('message', function(message) {
+  fetchingCachedBuilds = (message.data == 'cached');
+});
+
+toolbox.router.get(/build.servo.org\/json\/builders\/.*\/builds/,
+                   function(request, values, options) {
+  // For current builds we always try to get from the network first.
+  // For server cached builds, it's fine to go straight to the local cache.
+  if (fetchingCachedBuilds) {
+    return toolbox.cacheFirst(request, values, options);
+  }
+  return toolbox.networkFirst(request, values, options);
+});
 
 toolbox.router.get('/(.*)', function(request, values, options) {
   // networkFirst will attempt to return a response from the network,


### PR DESCRIPTION
Fixes #4.

This does not strictly avoid re-fetching, but it avoids hitting the network for cached builds. It dramatically speeds up the search process after the first run.