### PR TITLE
Create gulp serve task and use watch task only for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ You can serve this tool from http://localhost:3000 just by running this command:
 ```bash
 gulp
 ```
+
+You can develop this tool from http://localhost:3000 just by running this command:
+```bash
+gulp dev
+```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,3 +56,7 @@ gulp.task('dev', ['build'], function () {
 
   gulp.watch(entries, ['watch']);
 });
+
+gulp.task('serve', ['build'], serve('dist'));
+
+gulp.task('default', ['clean', 'copy', 'build', 'serve']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ gulp.task('watch', ['build'], function (done) {
   done();
 })
 
-gulp.task('default', ['clean', 'copy', 'build'], function () {
+gulp.task('dev', ['build'], function () {
   browserSync.init({
     server: {
       baseDir: './dist'


### PR DESCRIPTION
Fix #10 

r? @ferjm 

With this patch, we can use `gulp dev` to develop with `browsersync`.
Then, the default task will just serve this tool on 3000 port.